### PR TITLE
APIからデータ取得の実装

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_API_BASE_URL=http://localhost:3000

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -3,7 +3,7 @@ import Head from 'next/head';
 import { useState } from 'react';
 import { colors, fontSizes } from 'src/styles/Tokens';
 import { ShopItemDetail } from 'src/types/shopItem';
-import { getApi, HttpError } from 'src/utils/api';
+import { getApi, ApiResponseError } from 'src/utils/api';
 
 const Home: NextPage = () => {
   const [data, setData] = useState<ShopItemDetail>();
@@ -34,7 +34,7 @@ const Home: NextPage = () => {
             });
             setData(res);
           } catch (error) {
-            if (error instanceof HttpError) {
+            if (error instanceof ApiResponseError) {
               // eslint-disable-next-line no-console
               console.error(error);
             }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,24 +1,52 @@
 import type { NextPage } from 'next';
 import Head from 'next/head';
+import { useState } from 'react';
 import { colors, fontSizes } from 'src/styles/Tokens';
+import { ShopItemDetail } from 'src/types/shopItem';
+import { getApi, HttpError } from 'src/utils/api';
 
-const Home: NextPage = () => (
-  <div>
-    <Head>
-      <title>Yumeshop</title>
-      <meta name="description" content="" />
-      <link rel="icon" href="/favicon.ico" />
-    </Head>
+const Home: NextPage = () => {
+  const [data, setData] = useState<ShopItemDetail>();
 
-    <div
-      css={{
-        color: colors.Red,
-        fontSize: fontSizes.fontSize32,
-      }}
-    >
-      テスト
+  return (
+    <div>
+      <Head>
+        <title>Yumeshop</title>
+        <meta name="description" content="" />
+        <link rel="icon" href="/favicon.ico" />
+      </Head>
+
+      <div
+        css={{
+          color: colors.Red,
+          fontSize: fontSizes.fontSize32,
+        }}
+      >
+        テスト
+      </div>
+      <button
+        type="button"
+        onClick={async () => {
+          try {
+            // const res = await getApi("/shop_items")
+            const res = await getApi('/shop_items/:id', {
+              id: '4dfd9672-5633-4328-b104-832e2f18c2a7',
+            });
+            setData(res);
+          } catch (error) {
+            if (error instanceof HttpError) {
+              // eslint-disable-next-line no-console
+              console.error(error);
+            }
+          }
+        }}
+      >
+        fetch
+      </button>
+
+      {JSON.stringify(data)}
     </div>
-  </div>
-);
+  );
+};
 
 export default Home;

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,0 +1,23 @@
+/* eslint-disable @typescript-eslint/ban-types */
+
+import { ShopItem, ShopItemDetail } from './shopItem';
+
+type Schema<
+  T extends Record<
+    'GET' | 'POST' | 'PUT' | 'DELETE',
+    { [url: string]: [object | undefined, object | undefined] }
+  >,
+> = T;
+
+export type Api = Schema<{
+  // メソッド名: {
+  //   url: [リクエストの型、レスポンスの型]
+  // }
+  GET: {
+    '/shop_items': [undefined, ShopItem[]];
+    '/shop_items/:id': [{ id: string }, ShopItemDetail];
+  };
+  POST: {};
+  PUT: {};
+  DELETE: {};
+}>;

--- a/src/types/shopItem.ts
+++ b/src/types/shopItem.ts
@@ -11,37 +11,30 @@ export type ShopItem = {
   name: string;
   thumbnail: string;
   price: Price;
-  tags: [
-    {
-      id: string;
-      name: string;
-      color: string;
-      tag_group: string;
-    },
-  ];
-  campaigns: [
-    {
-      id: string;
-      name: string;
-      thumbnail: string;
-    },
-  ];
-  categories: [
-    {
-      id: string;
-      name: string;
-      thumbnail: string;
-    },
-  ];
+  tags: {
+    id: string;
+    name: string;
+    color: string;
+    tag_group: string;
+  }[];
+  campaigns: {
+    id: string;
+    name: string;
+    thumbnail: string;
+  }[];
+
+  categories: {
+    id: string;
+    name: string;
+    thumbnail: string;
+  }[];
 };
 
 export type ShopItemDetail = ShopItem & {
-  details: [
-    {
-      header: string;
-      content: string;
-    },
-  ];
+  details: {
+    header: string;
+    content: string;
+  }[];
   images: string[];
   related_shop_items: ShopItem[];
 };

--- a/src/types/shopItem.ts
+++ b/src/types/shopItem.ts
@@ -1,14 +1,16 @@
+type Price = {
+  selling_price: number;
+  original_price: number;
+  discounted: boolean;
+  discount_percentage: number;
+  discount_amount: number;
+};
+
 export type ShopItem = {
   id: string;
   name: string;
   thumbnail: string;
-  price: {
-    selling_price: number;
-    original_price: number;
-    discounted: boolean;
-    discount_percentage: number;
-    discount_amount: number;
-  };
+  price: Price;
   tags: [
     {
       id: string;

--- a/src/types/shopItem.ts
+++ b/src/types/shopItem.ts
@@ -1,0 +1,45 @@
+export type ShopItem = {
+  id: string;
+  name: string;
+  thumbnail: string;
+  price: {
+    selling_price: number;
+    original_price: number;
+    discounted: boolean;
+    discount_percentage: number;
+    discount_amount: number;
+  };
+  tags: [
+    {
+      id: string;
+      name: string;
+      color: string;
+      tag_group: string;
+    },
+  ];
+  campaigns: [
+    {
+      id: string;
+      name: string;
+      thumbnail: string;
+    },
+  ];
+  categories: [
+    {
+      id: string;
+      name: string;
+      thumbnail: string;
+    },
+  ];
+};
+
+export type ShopItemDetail = ShopItem & {
+  details: [
+    {
+      header: string;
+      content: string;
+    },
+  ];
+  images: string[];
+  related_shop_items: ShopItem[];
+};

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,0 +1,140 @@
+import { Api } from 'src/types/api';
+import { isEmptyObj } from './isEmptyObj';
+
+const BASE_URL = 'http://localhost:3000';
+
+export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE';
+
+export class HttpError extends Error {
+  url: string;
+
+  statusText: string;
+
+  message: string;
+
+  constructor(url: string, statusText: string, message: string) {
+    super();
+    this.name = 'HttpError';
+    this.url = url;
+    this.statusText = statusText;
+    this.message = message;
+  }
+
+  public static init = async (response: Response) => {
+    const json = (await response.json()) as { message: string };
+    return new HttpError(
+      response.url,
+      `${response.status} ${response.statusText}`,
+      json.message,
+    );
+  };
+}
+
+// 余剰プロパティチェック
+export type StrictPropertyCheck<T, TExpected> = Exclude<
+  keyof T,
+  keyof TExpected
+> extends never
+  ? T
+  : never;
+
+export const fetchApi = async <T>(
+  url: string,
+  method: HttpMethod,
+  params?: Record<string, unknown>,
+  headers?: Record<string, string>,
+): Promise<T> => {
+  let requestUrl = url;
+  let requestParams = { ...params };
+  const requestHeaders = headers || {};
+
+  if (method === 'GET') {
+    // /example/:id -> /example/1
+    requestUrl = url
+      .split('/')
+      .map((segment) => {
+        if (segment[0] === ':' && params) {
+          const { [segment.slice(1)]: _embedInUrl, ...rest } = requestParams;
+          requestParams = rest;
+          return params[segment.slice(1)] as string;
+        }
+        return segment;
+      })
+      .join('/');
+
+    // /example/1 -> /example/1?searchWord="あああ"
+    if (!isEmptyObj(requestParams)) {
+      requestUrl += `?${Object.entries(requestParams)
+        .map(([key, value]) => `${key}=${value}`)
+        .join('&')}`;
+      requestParams = {};
+    }
+  }
+
+  if (!isEmptyObj(requestParams)) {
+    requestHeaders['Content-Type'] = 'application/json';
+  }
+
+  let result;
+  try {
+    const res = await fetch(encodeURI(`${BASE_URL}${requestUrl}`), {
+      method,
+      body: isEmptyObj(requestParams) ? null : JSON.stringify(requestParams),
+      headers: { ...requestHeaders },
+    });
+
+    if (!res.ok) {
+      throw await HttpError.init(res);
+    }
+    result = await res.json();
+  } catch (error) {
+    if (error instanceof HttpError) {
+      throw error;
+    }
+  }
+
+  return result as T;
+};
+
+export const getApi = async <
+  Url extends keyof Api['GET'],
+  Request extends Api['GET'][Url][0],
+  Response extends Api['GET'][Url][1],
+>(
+  url: Url,
+  ...args: Request extends undefined
+    ? []
+    : [StrictPropertyCheck<Request, Api['GET'][Url][0]>]
+) => fetchApi<Response>(url, 'GET', args.at(0));
+
+export const postApi = async <
+  Url extends keyof Api['POST'],
+  Request extends Api['POST'][Url][0],
+  Response extends Api['POST'][Url][1],
+>(
+  url: Url,
+  ...args: Request extends undefined
+    ? []
+    : [StrictPropertyCheck<Request, Api['POST'][Url][0]>]
+) => fetchApi<Response>(url, 'POST', args.at(0));
+
+export const putApi = async <
+  Url extends keyof Api['PUT'],
+  Request extends Api['PUT'][Url][0],
+  Response extends Api['PUT'][Url][1],
+>(
+  url: Url,
+  ...args: Request extends undefined
+    ? []
+    : [StrictPropertyCheck<Request, Api['PUT'][Url][0]>]
+) => fetchApi<Response>(url, 'PUT', args.at(0));
+
+export const deleteApi = async <
+  Url extends keyof Api['DELETE'],
+  Request extends Api['DELETE'][Url][0],
+>(
+  url: Url,
+  ...args: Request extends undefined
+    ? []
+    : [StrictPropertyCheck<Request, Api['DELETE'][Url][0]>]
+) => fetchApi<undefined>(url, 'DELETE', args.at(0));

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -3,7 +3,7 @@ import { isEmptyObj } from './isEmptyObj';
 
 export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE';
 
-export class HttpError extends Error {
+export class ApiResponseError extends Error {
   url: string;
 
   statusText: string;
@@ -12,7 +12,7 @@ export class HttpError extends Error {
 
   constructor(url: string, statusText: string, message: string) {
     super();
-    this.name = 'HttpError';
+    this.name = 'ApiResponseError';
     this.url = url;
     this.statusText = statusText;
     this.message = message;
@@ -20,7 +20,7 @@ export class HttpError extends Error {
 
   public static init = async (response: Response) => {
     const json = (await response.json()) as { message: string };
-    return new HttpError(
+    return new ApiResponseError(
       response.url,
       `${response.status} ${response.statusText}`,
       json.message,
@@ -85,11 +85,11 @@ export const fetchApi = async <T>(
     );
 
     if (!res.ok) {
-      throw await HttpError.init(res);
+      throw await ApiResponseError.init(res);
     }
     result = await res.json();
   } catch (error) {
-    if (error instanceof HttpError) {
+    if (error instanceof ApiResponseError) {
       throw error;
     }
   }

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,8 +1,6 @@
 import { Api } from 'src/types/api';
 import { isEmptyObj } from './isEmptyObj';
 
-const BASE_URL = 'http://localhost:3000';
-
 export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE';
 
 export class HttpError extends Error {
@@ -77,11 +75,14 @@ export const fetchApi = async <T>(
 
   let result;
   try {
-    const res = await fetch(encodeURI(`${BASE_URL}${requestUrl}`), {
-      method,
-      body: isEmptyObj(requestParams) ? null : JSON.stringify(requestParams),
-      headers: { ...requestHeaders },
-    });
+    const res = await fetch(
+      encodeURI(`${process.env.NEXT_PUBLIC_API_BASE_URL}${requestUrl}`),
+      {
+        method,
+        body: isEmptyObj(requestParams) ? null : JSON.stringify(requestParams),
+        headers: { ...requestHeaders },
+      },
+    );
 
     if (!res.ok) {
       throw await HttpError.init(res);

--- a/src/utils/isEmptyObj.ts
+++ b/src/utils/isEmptyObj.ts
@@ -1,0 +1,1 @@
+export const isEmptyObj = (obj: object) => Object.entries(obj).length === 0;


### PR DESCRIPTION
## 関連 Task
APIからデータ取得の実装
https://www.notion.so/yumemi/API-831586e3b78649bd9376e965813f22eb

## 詳細

- 基本的なCRUD処理ができる関数を作成しました

## このPRに含めないTask
SWR導入
https://www.notion.so/yumemi/SWR-66e8335942ab46de83de465fb7803395

## 動作確認

- [x] 正常にGETできること（他のメソッドはまだ動作確認できていませんが、一旦進めます）

## 使い方
・[src/types/api.ts](https://github.com/tosssssy/yumeshop-frontend/pull/4/files#diff-bdd1d2421dd8a9a482f33554738b04c31fda4e51cefcf0270349c50e31729ab7)でリクエストの型・レスポンスの型を定義する。
・メソッドに合わせて関数を使う。第1引数はurl、第2引数はbody部分(GETのみクエリパラメータになる)
・urlにidなどが含まれている時は「:id」として表現し、body部分に書く
例：`getApi('/shop_items/:id', { id: "veresfdfsa" })`